### PR TITLE
added general annotations to plsyn

### DIFF
--- a/owl2_plsyn.pl
+++ b/owl2_plsyn.pl
@@ -199,7 +199,10 @@ plsyn2owl(Pl,Owl) :-
         maplist(plsyn2owl,Args,Args2),
         Owl=..[OwlPred,[Args2]].
 
-% TODO: entity annotations
+% Entity annotation
+plsyn2owl(Annot of Ent -- Text,annotationAssertion(Annot,Ent,literal(Text))):- !.
+
+% TODO: Axiom annotation  -- the existing definition below doesn't work
 plsyn2owl(Ax--Comments,[PlAx,axiomAnnotation('rdfs:comment',literal(Comments))]) :-
         !,
         plsyn2owl(Ax,PlAx).

--- a/testfiles/annot1.plsyn
+++ b/testfiles/annot1.plsyn
@@ -1,0 +1,29 @@
+ontology('http://temp.org/temp.ttl').
+
+%%%% some common annotation declarations
+annotationProperty('http://www.w3.org/2000/01/rdf-schema#label').
+annotationProperty('http://www.w3.org/2000/01/rdf-schema#comment').
+annotationProperty('http://purl.org/dc/elements/1.1/description').
+annotationProperty('http://purl.org/dc/elements/1.1/title').
+annotationProperty('http://xmlns.com/foaf/0.1/homepage').
+
+%%%% an annotation property that is part of the ontology in this file
+annotationProperty('http://temp.org/temp.ttl#description').
+
+
+%%%% annotation examples
+'dc:title' of 'http://temp.org/temp.ttl' -- 'An ontology with annotation examples'.
+'foaf:homepage' of 'http://temp.org/temp.ttl' -- 'http://temp.org/temp.ttl'.
+'dc:description' of fu -- 'the first syllable of fubar'.
+'rdfs:label' of fu -- fu.
+
+%%%%    readability is improved with localised annotation properties. For this,
+%       we can declare a local annotation property to be equivalent to a property in another namespace
+%
+description =@= 'dc:description'.
+description of bar -- 'the second syllable of fubar'.
+
+
+%%%% annotation on an entire axiom.  This doesn't work in the current owl_plsyn.pl code 
+% fu < bar -- 'axiom notation: fubar'.
+

--- a/testfiles/annot_plsyn.pl
+++ b/testfiles/annot_plsyn.pl
@@ -1,0 +1,12 @@
+% testing general (entity) annotations
+
+% load the thea modules
+:- use_module(library(thea2/owl2_io)).
+:- use_module(library(thea2/owl2_model)).
+:- use_module(library(thea2/owl2_util)).
+
+% load the plsyn ontology example that contains entity annotations...
+:- load_axioms('annot1.plsyn',plsyn).
+
+% ... and translate to owl format to check annotations are correct
+:- save_axioms('annot1.ttl',ttl).


### PR DESCRIPTION
The current version of `owl2_plsyn.pl` has annotations listed as TODO and the current stub for annotating axioms doesn't work (i.e. produces no export in, say, turtle exports).   Axiom annotation is in fact hardly ever used.  Far more common are entity annotations like `AnnotationAssertion(rdfs:label, a:Person "set of all people")`.

The submitted fix enables entity notations to be included in a `.plsyn` ontology file.  I keep the suggested `--` notation for annotations, but allow the left-hand side to have the structure like `label of entity`.   For example, 

    'dc:description' of people -- 'the set of all people'.

This style of entity annotation is enabled by a single line addition to the `owl2_plsyn.pl` file:

    plsyn2owl(Annot of Ent -- Text,annotationAssertion(Annot,Ent,literal(Text))):- !.

