### PR TITLE
Fix for prefixes

### DIFF
--- a/owl2_util.pl
+++ b/owl2_util.pl
@@ -235,9 +235,9 @@ replace_ns_prefix(_,_,X,X).
 contract_ns(URI,ID) :-
         atom(URI),
         rdf_global_id(NS:Local,URI),
-        NS \= rdf,
-        NS \= rdfs,
-        NS \= owl,
+%        NS \= rdf,
+%        NS \= rdfs,
+%        NS \= owl,
         !,
         atomic_list_concat([NS,Local],':',ID).
 contract_ns(X,X).
@@ -301,9 +301,12 @@ translate_IRIs(Goal):-
                               map_IRIs(Goal,O,O2)),
                            Os),
                    retract_axiom(A),
-                   assert_axiom(A2),
-                   forall(member(O,Os),
-                          assert_axiom(A2,O)))).
+                   (    Os=[]                   % avoid duplicate assertions 
+                   ->   assert_axiom(A2)
+                   ;    forall(member(O,Os),
+                          assert_axiom(A2,O))
+                   )
+                )).
 
 :- module_transparent translate_IRIs/2.
 translate_IRIs(Goal,Ontology):-

--- a/testfiles/prefix_test.pl
+++ b/testfiles/prefix_test.pl
@@ -1,0 +1,16 @@
+% testing prefix declarations
+
+% load the thea modules
+:- use_module(library(thea2/owl2_io)).
+:- use_module(library(thea2/owl2_model)).
+:- use_module(library(thea2/owl2_util)).
+
+% load and translate the plsyn ontology example that contains preferences.
+:- load_axioms('prefix_test1.plsyn',plsyn), save_axioms('prefix_test1.ttl',ttl).
+
+% reset, load and save the translation to check against original
+:- retract_all_axioms, load_axioms('prefix_test1.ttl',ttl), contract_namespaces, save_axioms('prefix_test2.plsyn',plsyn).
+
+% reset, load and save again to check round trip on ttl
+:- retract_all_axioms, load_axioms('prefix_test2.plsyn',plsyn), save_axioms('prefix_test3.ttl',ttl).
+

--- a/testfiles/prefix_test1.plsyn
+++ b/testfiles/prefix_test1.plsyn
@@ -1,0 +1,24 @@
+ontology('http://temp.org/temp.ttl').
+
+%%%% using namespaces that are known by default
+annotationProperty('rdfs:label').
+annotationProperty('rdfs:comment').
+annotationProperty('dc:description').
+annotationProperty('dc:title').
+annotationProperty('foaf:homepage').
+
+%%%% declaring a new namespace prefix
+pref(cco, 'http://www.ontologyrepository.com/CommonCoreOntologies/').
+
+%%% ...and an annotation properties based on the new prefix
+annotationProperty('cco:acronym').
+
+%%%% annotation examples
+'dc:title' of 'http://temp.org/temp.ttl' -- 'An ontology with annotation examples'.
+'foaf:homepage' of 'http://temp.org/temp.ttl' -- 'http://temp.org/temp.ttl'.
+
+'dc:description' of fu -- 'the first syllable of fubar'.
+'rdfs:label' of fu -- fu.
+
+'cco:acronym' of bar -- 'beyond all recognition'.
+

--- a/testfiles/template.ttl
+++ b/testfiles/template.ttl
@@ -1,0 +1,49 @@
+@prefix :       <http://temp/temp.ttl#> .
+
+@prefix owl:    <http://www.w3.org/2002/07/owl#> .
+@prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dc:     <http://purl.org/dc/elements/1.1/> .
+@prefix foaf:   <http://xmlns.com/foaf/0.1/> .
+
+@prefix bfo:    <http://purl.obolibrary.org/obo/bfo.owl#> .
+@prefix ro:     <http://www.obofoundry.org/ro/ro.owl#> .
+@prefix obo:    <http://purl.obolibrary.org/obo/> .
+@prefix cco:    <http://www.ontologyrepository.com/CommonCoreOntologies/> .
+
+@base <http://temp/temp.ttl> .
+
+# Annotation Properties
+rdfs:label      a owl:AnnotationProperty.
+rdfs:comment    a owl:AnnotationProperty.
+:description    a owl:AnnotationProperty ; owl:equivalentProperty dc:description .
+:definition     a owl:AnnotationProperty ; owl:equivalentProperty cco:definition .
+:source         a owl:AnnotationProperty ; owl:equivalentProperty cco:definition_source .
+:acronym        a owl:AnnotationProperty ; owl:equivalentProperty cco:acronym .
+:altlabel       a owl:AnnotationProperty ; owl:equivalentProperty cco:alternative_label .
+:usage          a owl:AnnotationProperty ; owl:equivalentProperty cco:example_of_usage .
+
+# The ontology itself defined as a thing
+<http://temp/temp.ttl>  
+    a owl:Ontology ;
+    owl:versionIRI <https://github.com/TempAccount/temp/temp.ttl/1.0.0> ;
+    dc:title "Ontology Template" ;
+    foaf:homepage "https://github.com/TempAccount/temp" ;
+    :description "An ontology template." .
+
+<fu>
+    a owl:Class;
+    rdfs:subClass of :bar;
+    rdfs:label literal("fu");
+    :description literal("fu is the first syllable of fubar").
+
+<bar>
+    a owl:Class;
+    rdfs:subClass of owl:thing;
+    rdfs:label literal("bar");
+    :description literal("bar is the second syllable of fubar").
+
+
+
+


### PR DESCRIPTION
The plsyn ontology syntax was missing the ability to declare prefixes.  This pull request provides that.  Declare a prefix in a .plsyn file like the following example

~~~
pref(cco, 'http://www.ontologyrepository.com/CommonCoreOntologies/').
~~~
(the predicate `pref/2` is used so not to conflict with the swi-prolog `prefix/2` predicate)

Prefixes are implemented using the `semweb/rdf_prefixes` library in the `owl2_plsyn` module.  Specifically, in the `owl_parse_plsyn/2` predicate, I check to see if the term read from the plsyn file is a prefix declaration, in which case the prefix is registered.  The rest of plsyn processing can proceed as normal, because prefixes are already handled correctly, as long as the prefix is registered.

In the reverse direction of saving a plsyn file, we have to check if any non-default prefixes were registered and write those as `pref/2` clauses in the plsyn file.  A new predicate `write_plsyn_prefixes/0` is called from the `write_owl_as_plsyn/1` predicate to handle this.

This fix also corrects some minor issues that were discovered during implementation:   
* writing annotations in the infix format of P of S -- O, rather than prefix format
* avoiding duplicating axioms during `contract_namespaces` (in the `owl2_util.pl` module)

A unit test file (`prefix_test.pl`) is included that executes several round-trip conversions starting with the test file `prefix_test1.plsyn`.